### PR TITLE
PN-2381 aggiunto consumer Kafka che scoda gli onboarding

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -38,3 +38,8 @@ pn.external-registry.dynamodb_table-name-onboard-institutions=OnboardInstitution
 aws.region-code=us-east-1
 aws.profile-name=${PN_AWS_PROFILE_NAME:default}
 aws.endpoint-url=http://localhost:4566
+
+#Kafka bootstrap servers local config
+spring.kafka.consumer.bootstrap-servers=PLAINTEXT://localhost:29092
+spring.kafka.consumer.properties.security.protocol=PLAINTEXT
+pn.external-registry.kafka-onboarding-group-id=pn-external-registries-local

--- a/config/application.properties
+++ b/config/application.properties
@@ -39,6 +39,7 @@ aws.region-code=us-east-1
 aws.profile-name=${PN_AWS_PROFILE_NAME:default}
 aws.endpoint-url=http://localhost:4566
 
+
 #Kafka bootstrap servers local config
 spring.kafka.consumer.bootstrap-servers=PLAINTEXT://localhost:29092
 spring.kafka.consumer.properties.security.protocol=PLAINTEXT

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,15 @@
             <version>2.11.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/scripts/aws/cfn/microservice-dev-cfg.json
+++ b/scripts/aws/cfn/microservice-dev-cfg.json
@@ -5,6 +5,8 @@
     "CheckoutCartApiBaseUrl": "https://api.uat.platform.pagopa.it/checkout/ec/v1",
     "SelfcareUsergroupBaseUrl": "https://api.uat.selfcare.pagopa.it/external/v1",
     "PortalUrl": "https://portale-login.dev.pn.pagopa.it",
-    "SelfcareUsergroupPnProductId": "prod-pn-dev"
+    "SelfcareUsergroupPnProductId": "prod-pn-dev",
+    "KafkaOnBoardingTopicName": "sc-contracts",
+    "KafkaOnBoardingGroupId": "pn-external-registries-dev"
   }
 }

--- a/scripts/aws/cfn/microservice-dev-cfg.json
+++ b/scripts/aws/cfn/microservice-dev-cfg.json
@@ -7,6 +7,7 @@
     "PortalUrl": "https://portale-login.dev.pn.pagopa.it",
     "SelfcareUsergroupPnProductId": "prod-pn-dev",
     "KafkaOnBoardingTopicName": "sc-contracts",
-    "KafkaOnBoardingGroupId": "pn-external-registries-dev"
+    "KafkaOnBoardingGroupId": "pn-external-registries-dev",
+    "KafkaOnBoardingBootstrapServers": "selc-u-eventhub-ns.servicebus.windows.net:9093"
   }
 }

--- a/scripts/aws/cfn/microservice-svil-cfg.json
+++ b/scripts/aws/cfn/microservice-svil-cfg.json
@@ -5,6 +5,8 @@
     "CheckoutCartApiBaseUrl": "https://api.uat.platform.pagopa.it/checkout/ec/v1",
     "SelfcareUsergroupBaseUrl": "https://api.uat.selfcare.pagopa.it/external/v1",
     "PortalUrl": "https://portale-login.svil.pn.pagopa.it",
-    "SelfcareUsergroupPnProductId": "prod-pn-svil"
+    "SelfcareUsergroupPnProductId": "prod-pn-svil",
+    "KafkaOnBoardingTopicName": "sc-contracts",
+    "KafkaOnBoardingGroupId": "pn-external-registries-svil"
   }
 }

--- a/scripts/aws/cfn/microservice-svil-cfg.json
+++ b/scripts/aws/cfn/microservice-svil-cfg.json
@@ -7,6 +7,7 @@
     "PortalUrl": "https://portale-login.svil.pn.pagopa.it",
     "SelfcareUsergroupPnProductId": "prod-pn-svil",
     "KafkaOnBoardingTopicName": "sc-contracts",
-    "KafkaOnBoardingGroupId": "pn-external-registries-svil"
+    "KafkaOnBoardingGroupId": "pn-external-registries-svil",
+    "KafkaOnBoardingBootstrapServers": "selc-u-eventhub-ns.servicebus.windows.net:9093"
   }
 }

--- a/scripts/aws/cfn/microservice-uat-cfg.json
+++ b/scripts/aws/cfn/microservice-uat-cfg.json
@@ -5,6 +5,8 @@
     "CheckoutCartApiBaseUrl": "https://api.uat.platform.pagopa.it/checkout/ec/v1",
     "SelfcareUsergroupBaseUrl": "https://api.uat.selfcare.pagopa.it/external/v1",
     "PortalUrl": "https://portale-login.uat.pn.pagopa.it",
-    "SelfcareUsergroupPnProductId": "prod-pn-uat"
+    "SelfcareUsergroupPnProductId": "prod-pn-uat",
+    "KafkaOnBoardingTopicName": "sc-contracts",
+    "KafkaOnBoardingGroupId": "pn-external-registries-uat"
   }
 }

--- a/scripts/aws/cfn/microservice-uat-cfg.json
+++ b/scripts/aws/cfn/microservice-uat-cfg.json
@@ -7,6 +7,7 @@
     "PortalUrl": "https://portale-login.uat.pn.pagopa.it",
     "SelfcareUsergroupPnProductId": "prod-pn-uat",
     "KafkaOnBoardingTopicName": "sc-contracts",
-    "KafkaOnBoardingGroupId": "pn-external-registries-uat"
+    "KafkaOnBoardingGroupId": "pn-external-registries-uat",
+    "KafkaOnBoardingBootstrapServers": "selc-u-eventhub-ns.servicebus.windows.net:9093"
   }
 }

--- a/scripts/aws/cfn/microservice.yml
+++ b/scripts/aws/cfn/microservice.yml
@@ -129,18 +129,17 @@ Parameters:
   KafkaOnBoardingTopicName:
     Type: String
     Description: 'Kafka topic name for onboarding institutions'
+    Default: 'sc-contracts'
 
   KafkaOnBoardingGroupId:
     Type: String
     Description: 'Kafka group id for onboarding institutions'
+    Default: ''
 
   KafkaOnBoardingBootstrapServers:
     Type: String
     Description: 'Kafka bootstrap servers'
-
-  KafkaOnBoardingSaslJaasConfig:
-    Type: String
-    Description: 'Kafka sasl jaas config for onboarding institutions'
+    Default: ''
 
 Resources:
 
@@ -176,7 +175,7 @@ Resources:
         ContainerEnvEntry20: !Sub 'PN_EXTERNAL_REGISTRY_KAFKA_ONBOARDING_TOPIC_NAME=${KafkaOnBoardingTopicName}'
         ContainerEnvEntry21: !Sub 'PN_EXTERNAL_REGISTRY_KAFKA_ONBOARDING_GROUP_ID=${KafkaOnBoardingGroupId}'
         ContainerEnvEntry22: !Sub 'SPRING_KAFKA_CONSUMER_BOOTSTRAP_SERVERS=${KafkaOnBoardingBootstrapServers}'
-        ContainerEnvEntry23: !Sub 'KAFKA_ONBOARDING_SASL_JAAS_PASSWORD=${KafkaOnBoardingSaslJaasConfig}'
+        ContainerEnvEntry23: !Sub 'KAFKA_ONBOARDING_SASL_JAAS_PASSWORD={{resolve:secretsmanager:${ProjectName}-ExternalRegistries-Secrets:SecretString:KafkaOnBoardingSaslJaasConfig}}'
         MappedPaths: '/ext-registry/*,/ext-registry-private/*,/ext-registry-b2b/*'
         ECSClusterName: !Ref ECSClusterName
         Subnets: !Ref SubnetsIds

--- a/scripts/aws/cfn/microservice.yml
+++ b/scripts/aws/cfn/microservice.yml
@@ -126,6 +126,22 @@ Parameters:
     Type: String
     Description: 'Application load balancer security group'
 
+  KafkaOnBoardingTopicName:
+    Type: String
+    Description: 'Kafka topic name for onboarding institutions'
+
+  KafkaOnBoardingGroupId:
+    Type: String
+    Description: 'Kafka group id for onboarding institutions'
+
+  KafkaOnBoardingBootstrapServers:
+    Type: String
+    Description: 'Kafka bootstrap servers'
+
+  KafkaOnBoardingSaslJaasConfig:
+    Type: String
+    Description: 'Kafka sasl jaas config for onboarding institutions'
+
 Resources:
 
   # PN-External-Registry microservice
@@ -157,6 +173,10 @@ Resources:
         ContainerEnvEntry17: !Sub 'PN_EXTERNAL_REGISTRY_TOPICS_DELIVERY_PUSH_INPUT=${DeliveryPushInputsQueueName}'
         ContainerEnvEntry18: !Sub 'PN_EXTERNAL_REGISTRY_CHECKOUT_CART_API_BASE_URL=${CheckoutCartApiBaseUrl}'
         ContainerEnvEntry19: !Sub 'PN_EXTERNAL_REGISTRY_DYNAMODB_TABLE_NAME_ONBOARD_INSTITUTIONS=${OnboardInstitutionsTableName}'
+        ContainerEnvEntry20: !Sub 'PN_EXTERNAL_REGISTRY_KAFKA_ONBOARDING_TOPIC_NAME=${KafkaOnBoardingTopicName}'
+        ContainerEnvEntry21: !Sub 'PN_EXTERNAL_REGISTRY_KAFKA_ONBOARDING_GROUP_ID=${KafkaOnBoardingGroupId}'
+        ContainerEnvEntry22: !Sub 'SPRING_KAFKA_CONSUMER_BOOTSTRAP_SERVERS=${KafkaOnBoardingBootstrapServers}'
+        ContainerEnvEntry23: !Sub 'KAFKA_ONBOARDING_SASL_JAAS_PASSWORD=${KafkaOnBoardingSaslJaasConfig}'
         MappedPaths: '/ext-registry/*,/ext-registry-private/*,/ext-registry-b2b/*'
         ECSClusterName: !Ref ECSClusterName
         Subnets: !Ref SubnetsIds

--- a/src/main/java/it/pagopa/pn/external/registries/mapper/OnBoardSelfCareToOnBoardInstituteEntityMapper.java
+++ b/src/main/java/it/pagopa/pn/external/registries/mapper/OnBoardSelfCareToOnBoardInstituteEntityMapper.java
@@ -1,0 +1,24 @@
+package it.pagopa.pn.external.registries.mapper;
+
+import it.pagopa.pn.external.registries.middleware.db.entities.OnboardInstitutionEntity;
+import it.pagopa.pn.external.registries.middleware.queue.consumer.kafka.onboarding.onboarding.OnBoardingSelfCareDTO;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+@Component
+public class OnBoardSelfCareToOnBoardInstituteEntityMapper {
+
+    public OnboardInstitutionEntity toEntity(OnBoardingSelfCareDTO onBoardingSelfCareDTO) {
+        OnboardInstitutionEntity entity = new OnboardInstitutionEntity();
+        entity.setStatus(onBoardingSelfCareDTO.getState());
+        entity.setLastUpdate(Instant.from(onBoardingSelfCareDTO.getUpdatedAt()));
+        entity.setTaxCode(onBoardingSelfCareDTO.getInstitution().getTaxCode());
+        entity.setAddress(onBoardingSelfCareDTO.getInstitution().getAddress());
+        entity.setDigitalAddress(onBoardingSelfCareDTO.getInstitution().getDigitalAddress());
+        entity.setDescription(onBoardingSelfCareDTO.getInstitution().getDescription());
+        entity.setPk(onBoardingSelfCareDTO.getInternalIstitutionID());
+        entity.setExternalId(onBoardingSelfCareDTO.getOnboardingTokenId());
+        return entity;
+    }
+}

--- a/src/main/java/it/pagopa/pn/external/registries/middleware/db/dao/OnboardInstitutionsDao.java
+++ b/src/main/java/it/pagopa/pn/external/registries/middleware/db/dao/OnboardInstitutionsDao.java
@@ -56,4 +56,13 @@ public class OnboardInstitutionsDao extends BaseDao {
             Flux.from(onboardInstitutionsTable.index(GSI_INDEX_LASTUPDATE).query(queryEnhancedRequestACTIVE).flatMapIterable(Page::items)),
                  Flux.from(onboardInstitutionsTable.index(GSI_INDEX_LASTUPDATE).query(queryEnhancedRequestSUSPENDED).flatMapIterable(Page::items)));
     }
+
+    public Mono<Void> put(OnboardInstitutionEntity onboardInstitutionEntity) {
+         return Mono.fromFuture(onboardInstitutionsTable.putItem(onboardInstitutionEntity));
+    }
+
+    public Mono<OnboardInstitutionEntity> delete(String institutionId) {
+         return Mono.fromFuture(onboardInstitutionsTable.deleteItem(getKeyBuild(institutionId)));
+    }
+
 }

--- a/src/main/java/it/pagopa/pn/external/registries/middleware/db/dao/OnboardInstitutionsDao.java
+++ b/src/main/java/it/pagopa/pn/external/registries/middleware/db/dao/OnboardInstitutionsDao.java
@@ -61,8 +61,4 @@ public class OnboardInstitutionsDao extends BaseDao {
          return Mono.fromFuture(onboardInstitutionsTable.putItem(onboardInstitutionEntity));
     }
 
-    public Mono<OnboardInstitutionEntity> delete(String institutionId) {
-         return Mono.fromFuture(onboardInstitutionsTable.deleteItem(getKeyBuild(institutionId)));
-    }
-
 }

--- a/src/main/java/it/pagopa/pn/external/registries/middleware/queue/consumer/kafka/onboarding/onboarding/OnBoardingSelfCareConsumer.java
+++ b/src/main/java/it/pagopa/pn/external/registries/middleware/queue/consumer/kafka/onboarding/onboarding/OnBoardingSelfCareConsumer.java
@@ -1,0 +1,35 @@
+package it.pagopa.pn.external.registries.middleware.queue.consumer.kafka.onboarding.onboarding;
+
+import it.pagopa.pn.external.registries.mapper.OnBoardSelfCareToOnBoardInstituteEntityMapper;
+import it.pagopa.pn.external.registries.middleware.db.dao.OnboardInstitutionsDao;
+import it.pagopa.pn.external.registries.middleware.db.entities.OnboardInstitutionEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class OnBoardingSelfCareConsumer {
+
+    private final OnboardInstitutionsDao onboardInstitutionsDao;
+
+    private final OnBoardSelfCareToOnBoardInstituteEntityMapper mapper;
+
+    @KafkaListener(id = "${pn.external-registry.kafka-onboarding-group-id}", topics = "${pn.external-registry.kafka-onboarding-topic-name}")
+    public void listen(@Header(KafkaHeaders.RECEIVED_TOPIC) String topic, @Payload OnBoardingSelfCareDTO payload) {
+        log.info("Received message from topic: {}, with value: {}", topic, payload);
+
+        if(payload != null) {
+            OnboardInstitutionEntity entity = mapper.toEntity(payload);
+            onboardInstitutionsDao.put(entity).subscribe();
+            log.info("Entity saved from topic: {}, with value: {}", topic, entity);
+        }
+
+    }
+
+}

--- a/src/main/java/it/pagopa/pn/external/registries/middleware/queue/consumer/kafka/onboarding/onboarding/OnBoardingSelfCareDTO.java
+++ b/src/main/java/it/pagopa/pn/external/registries/middleware/queue/consumer/kafka/onboarding/onboarding/OnBoardingSelfCareDTO.java
@@ -1,0 +1,38 @@
+package it.pagopa.pn.external.registries.middleware.queue.consumer.kafka.onboarding.onboarding;
+
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+public class OnBoardingSelfCareDTO {
+
+    private Billing billing;
+    private String contentType;
+    private String fileName;
+    private String filePath;
+    private String id;
+    private Institution institution;
+    private String internalIstitutionID;
+    private String onboardingTokenId;
+    private String product;
+    private String state;
+    private Instant updatedAt;
+
+    @Data
+    public static class Billing {
+        private String recipientCode;
+        private String vatNumber;
+    }
+
+    @Data
+    public static class Institution{
+        private String address;
+        private String description;
+        private String digitalAddress;
+        private String institutionType;
+        private String origin;
+        private String originId;
+        private String taxCode;
+    }
+}

--- a/src/main/java/it/pagopa/pn/external/registries/middleware/queue/consumer/kafka/onboarding/onboarding/OnBoardingSelfCareDTODeserializer.java
+++ b/src/main/java/it/pagopa/pn/external/registries/middleware/queue/consumer/kafka/onboarding/onboarding/OnBoardingSelfCareDTODeserializer.java
@@ -1,0 +1,32 @@
+package it.pagopa.pn.external.registries.middleware.queue.consumer.kafka.onboarding.onboarding;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Deserializer;
+
+@Slf4j
+public class OnBoardingSelfCareDTODeserializer implements Deserializer<OnBoardingSelfCareDTO> {
+
+    private final ObjectMapper objectMapper;
+
+    public OnBoardingSelfCareDTODeserializer() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    @Override
+    public OnBoardingSelfCareDTO deserialize(String topic, byte[] data) {
+        try {
+            if (data == null){
+               log.warn("Null received at deserializing");
+                return null;
+            }
+            log.trace("Deserializing from topic: {}...", topic);
+            return objectMapper.readValue(data, OnBoardingSelfCareDTO.class);
+        } catch (Exception e) {
+            throw new SerializationException(String.format("Error when deserializing byte[] to OnBoardingSelfCareDTO with input: %s", new String(data)), e);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,3 +25,16 @@ pn.external-registry.fulltextsearch-update-cron-expression=0 0 */1 * * *
 
 # Fix null object in serialization
 spring.jackson.default-property-inclusion = NON_NULL
+
+#kafka global settings
+spring.kafka.consumer.enable-auto-commit=true
+spring.kafka.consumer.auto-commit-interval=1000
+spring.kafka.consumer.max-poll-records=250
+spring.kafka.consumer.heartbeat-interval=3000
+spring.kafka.consumer.auto-offset-reset=latest
+spring.kafka.consumer.value-deserializer=it.pagopa.pn.external.registries.middleware.queue.consumer.kafka.onboarding.onboarding.OnBoardingSelfCareDTODeserializer
+spring.kafka.consumer.properties.sasl.mechanism=PLAIN
+spring.kafka.consumer.properties.security.protocol=SASL_SSL
+spring.kafka.consumer.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="${KAFKA_ONBOARDING_SASL_JAAS_PASSWORD}";
+#
+pn.external-registry.kafka-onboarding-topic-name=sc-contracts

--- a/src/test/java/it/pagopa/pn/external/registries/middleware/db/io/dao/OnboardInstitutionDaoTestIT.java
+++ b/src/test/java/it/pagopa/pn/external/registries/middleware/db/io/dao/OnboardInstitutionDaoTestIT.java
@@ -4,16 +4,15 @@ import it.pagopa.pn.external.registries.LocalStackTestConfig;
 import it.pagopa.pn.external.registries.config.PnExternalRegistriesConfig;
 import it.pagopa.pn.external.registries.middleware.db.dao.OnboardInstitutionsDao;
 import it.pagopa.pn.external.registries.middleware.db.entities.OnboardInstitutionEntity;
+import it.pagopa.pn.external.registries.middleware.queue.consumer.kafka.onboarding.onboarding.OnBoardingSelfCareConsumer;
 import it.pagopa.pn.external.registries.middleware.queue.producer.sqs.SqsNotificationPaidProducer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
 
 import java.time.Duration;
@@ -41,6 +40,9 @@ class OnboardInstitutionDaoTestIT {
 
     @MockBean
     private SqsNotificationPaidProducer producer;
+
+    @MockBean
+    private OnBoardingSelfCareConsumer onBoardingSelfCareConsumer;
 
 
     @BeforeEach

--- a/src/test/java/it/pagopa/pn/external/registries/middleware/db/io/dao/OnboardInstitutionDaoTestIT.java
+++ b/src/test/java/it/pagopa/pn/external/registries/middleware/db/io/dao/OnboardInstitutionDaoTestIT.java
@@ -153,6 +153,31 @@ class OnboardInstitutionDaoTestIT {
         }
     }
 
+    @Test
+    void putTest() {
+        OnboardInstitutionEntity entity = newOnboard();
+        consentDao.put(entity);
+
+        try {
+            OnboardInstitutionEntity actual = testDao.get(entity.getInstitutionId(), null);
+            Assertions.assertEquals(entity, actual);
+        }
+        catch (Exception e) {
+            System.err.println(e.getMessage());
+        }
+        finally {
+            try {
+                testDao.delete(entity.getPk(), null);
+            }
+            catch (Exception e) {
+                System.out.println("Nothing to remove");
+            }
+
+        }
+
+
+    }
+
     private OnboardInstitutionEntity newOnboard() {
         OnboardInstitutionEntity res = new OnboardInstitutionEntity();
         res.setPk("12345");

--- a/src/test/java/it/pagopa/pn/external/registries/middleware/db/io/dao/OptInSentDaoTestIT.java
+++ b/src/test/java/it/pagopa/pn/external/registries/middleware/db/io/dao/OptInSentDaoTestIT.java
@@ -3,6 +3,7 @@ package it.pagopa.pn.external.registries.middleware.db.io.dao;
 import it.pagopa.pn.external.registries.LocalStackTestConfig;
 import it.pagopa.pn.external.registries.config.PnExternalRegistriesConfig;
 import it.pagopa.pn.external.registries.middleware.db.io.entities.OptInSentEntity;
+import it.pagopa.pn.external.registries.middleware.queue.consumer.kafka.onboarding.onboarding.OnBoardingSelfCareConsumer;
 import it.pagopa.pn.external.registries.middleware.queue.producer.sqs.SqsNotificationPaidProducer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +40,9 @@ class OptInSentDaoTestIT {
 
     @MockBean
     private SqsNotificationPaidProducer producer;
+
+    @MockBean
+    private OnBoardingSelfCareConsumer onBoardingSelfCareConsumer;
 
 
     @BeforeEach

--- a/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/CheckoutClientTest.java
+++ b/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/CheckoutClientTest.java
@@ -4,21 +4,16 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.pn.external.registries.config.PnExternalRegistriesConfig;
 import it.pagopa.pn.external.registries.generated.openapi.checkout.client.v1.dto.*;
-import it.pagopa.pn.external.registries.middleware.queue.producer.sqs.SqsNotificationPaidProducer;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.MediaType;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import reactor.test.StepVerifier;
 
 import java.net.URI;
@@ -28,12 +23,7 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
-@SpringBootTest(classes = {CheckoutClient.class, PnExternalRegistriesConfig.class})
-@ActiveProfiles("test")
-@TestPropertySource(properties = {
-        "pn.external-registry.checkout-api-base-url=http://localhost:9999",
-        "pn.external-registry.checkout-api-key=fake_api_key"
-})
+@ExtendWith(MockitoExtension.class)
 class CheckoutClientTest {
 
     private CheckoutClient client;
@@ -42,15 +32,6 @@ class CheckoutClientTest {
     private PnExternalRegistriesConfig cfg;
 
     private static ClientAndServer mockServer;
-
-    @Configuration
-    static class ContextConfiguration {
-        @Primary
-        @Bean
-        public SqsNotificationPaidProducer sqsNotificationPaidProducer() {
-            return Mockito.mock( SqsNotificationPaidProducer.class);
-        }
-    }
 
     @BeforeEach
     void setup() {

--- a/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcareUserGroupClientTest.java
+++ b/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcareUserGroupClientTest.java
@@ -6,19 +6,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.pn.external.registries.config.PnExternalRegistriesConfig;
 import it.pagopa.pn.external.registries.generated.openapi.selfcare.external.client.v1.dto.PageOfUserGroupResourceDto;
 import it.pagopa.pn.external.registries.generated.openapi.selfcare.external.client.v1.dto.UserGroupResourceDto;
-import it.pagopa.pn.external.registries.middleware.queue.producer.sqs.SqsNotificationPaidProducer;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.MediaType;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,29 +22,17 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
-@SpringBootTest(classes = {SelfcareUserGroupClient.class, PnExternalRegistriesConfig.class})
-@ActiveProfiles("test")
-@TestPropertySource(properties = {
-        "pn.external-registry.selfcareusergroup-base-url=http://localhost:9999"
-})
+@ExtendWith(MockitoExtension.class)
 class SelfcareUserGroupClientTest {
 
 
     private SelfcareUserGroupClient client;
 
-    @MockBean
+    @Mock
     private PnExternalRegistriesConfig cfg;
 
     private static ClientAndServer mockServer;
 
-    @Configuration
-    static class ContextConfiguration {
-        @Primary
-        @Bean
-        public SqsNotificationPaidProducer sqsNotificationPaidProducer() {
-            return Mockito.mock( SqsNotificationPaidProducer.class);
-        }
-    }
 
     @BeforeEach
     void setup() {

--- a/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/io/IOActivationClientTest.java
+++ b/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/io/IOActivationClientTest.java
@@ -6,6 +6,7 @@ import it.pagopa.pn.external.registries.config.PnExternalRegistriesConfig;
 import it.pagopa.pn.external.registries.generated.openapi.io.client.v1.dto.Activation;
 import it.pagopa.pn.external.registries.generated.openapi.io.client.v1.dto.ActivationPayload;
 import it.pagopa.pn.external.registries.generated.openapi.io.client.v1.dto.FiscalCodePayload;
+import it.pagopa.pn.external.registries.middleware.queue.consumer.kafka.onboarding.onboarding.OnBoardingSelfCareConsumer;
 import it.pagopa.pn.external.registries.middleware.queue.producer.sqs.SqsNotificationPaidProducer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -17,6 +18,7 @@ import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.MediaType;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -40,6 +42,9 @@ class IOCourtesyMessageClientTest {
 
     @Mock
     private PnExternalRegistriesConfig cfg;
+
+    @MockBean
+    private OnBoardingSelfCareConsumer onBoardingSelfCareConsumer;
 
     private ClientAndServer mockServer;
 

--- a/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/io/IOClientTest.java
+++ b/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/io/IOClientTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.pn.external.registries.config.PnExternalRegistriesConfig;
 import it.pagopa.pn.external.registries.generated.openapi.io.client.v1.dto.*;
-import it.pagopa.pn.external.registries.middleware.msclient.io.IOClient;
+import it.pagopa.pn.external.registries.middleware.queue.consumer.kafka.onboarding.onboarding.OnBoardingSelfCareConsumer;
 import it.pagopa.pn.external.registries.middleware.queue.producer.sqs.SqsNotificationPaidProducer;
 import org.junit.jupiter.api.*;
 import org.mockito.Mock;
@@ -12,14 +12,13 @@ import org.mockito.Mockito;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.MediaType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.util.Collections;
 
@@ -40,6 +39,9 @@ class IOOptInTest {
 
     @Mock
     private PnExternalRegistriesConfig cfg;
+
+    @MockBean
+    private OnBoardingSelfCareConsumer onBoardingSelfCareConsumer;
 
     private static ClientAndServer mockServer;
 

--- a/src/test/java/it/pagopa/pn/external/registries/middleware/queue/consumer/kafka/onboarding/OnBoardingSelfCareConsumerTestIT.java
+++ b/src/test/java/it/pagopa/pn/external/registries/middleware/queue/consumer/kafka/onboarding/OnBoardingSelfCareConsumerTestIT.java
@@ -100,4 +100,5 @@ class OnBoardingSelfCareConsumerTestIT {
                 """;
     }
 
+
 }

--- a/src/test/java/it/pagopa/pn/external/registries/middleware/queue/consumer/kafka/onboarding/OnBoardingSelfCareConsumerTestIT.java
+++ b/src/test/java/it/pagopa/pn/external/registries/middleware/queue/consumer/kafka/onboarding/OnBoardingSelfCareConsumerTestIT.java
@@ -1,0 +1,103 @@
+package it.pagopa.pn.external.registries.middleware.queue.consumer.kafka.onboarding;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import it.pagopa.pn.external.registries.LocalStackTestConfig;
+import it.pagopa.pn.external.registries.mapper.OnBoardSelfCareToOnBoardInstituteEntityMapper;
+import it.pagopa.pn.external.registries.middleware.db.dao.OnboardInstitutionsDao;
+import it.pagopa.pn.external.registries.middleware.db.entities.OnboardInstitutionEntity;
+import it.pagopa.pn.external.registries.middleware.queue.consumer.kafka.onboarding.onboarding.OnBoardingSelfCareConsumer;
+import it.pagopa.pn.external.registries.middleware.queue.consumer.kafka.onboarding.onboarding.OnBoardingSelfCareDTO;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.concurrent.ExecutionException;
+
+@SpringBootTest(properties = {
+        "spring.kafka.consumer.bootstrap-servers=PLAINTEXT://localhost:9092",
+        "spring.kafka.consumer.auto-offset-reset=earliest",
+        "pn.external-registry.kafka-pagamenti-group-id=consumer-test",
+        "spring.kafka.consumer.properties.security.protocol=PLAINTEXT"
+})
+@DirtiesContext
+@EmbeddedKafka(partitions = 1, brokerProperties = { "listeners=PLAINTEXT://localhost:9092", "port=9092" })
+@Import(LocalStackTestConfig.class)
+class OnBoardingSelfCareConsumerTestIT {
+
+    @SpyBean
+    private OnBoardingSelfCareConsumer onBoardingSelfCareConsumer;
+
+    @Autowired
+    private OnboardInstitutionsDao onboardInstitutionsDao;
+
+    @Autowired
+    private OnBoardSelfCareToOnBoardInstituteEntityMapper mapper;
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void listenOKTest() throws ExecutionException, InterruptedException, JsonProcessingException {
+        String inputRequest = inputRequestFormSelfCare();
+
+        //scrivo su Kafka una Request presa dal flusso reale di SelfCare
+        kafkaTemplate.send("sc-contracts", inputRequest).get();
+
+        OnBoardingSelfCareDTO expectedValue = objectMapper.readValue(inputRequest, OnBoardingSelfCareDTO.class);
+
+        //verifico che il consumer riceva correttamente il messaggio (e quindi il deserializer funzioni)
+        Mockito.verify(onBoardingSelfCareConsumer, Mockito.timeout(1000).times(1)).listen("sc-contracts", expectedValue);
+
+        //verifico che alla fine del flusso, il consumer abbia scritto su Dynamo, verificando che il record sia presente
+        Mono<OnboardInstitutionEntity> onboardInstitutionEntityMono = onboardInstitutionsDao.get("7861b02d-8cb4-4de9-95d2-5ed02f3de38a");
+
+        StepVerifier.create(onboardInstitutionEntityMono)
+                .expectNext(mapper.toEntity(expectedValue))
+                .verifyComplete();
+
+        //clean dynamodb
+        onboardInstitutionsDao.delete("7861b02d-8cb4-4de9-95d2-5ed02f3de38a").subscribe();
+    }
+
+    private String inputRequestFormSelfCare() {
+        return """
+                {
+                   "billing":{
+                      "recipientCode":"bc_0432",
+                      "vatNumber":"00338460090"
+                   },
+                   "contentType":"application/octet-stream",
+                   "fileName":"App IO_accordo_adesione.pdf7419256794741715935.pdf",
+                   "filePath":"parties/docs/7014954b-5a2f-4aed-9f26-b2b778c2a120/App IO_accordo_adesione.pdf7419256794741715935.pdf",
+                   "id":"7014954b-5a2f-4aed-9f26-b2b778c2a120",
+                   "institution":{
+                      "address":"Piazza Umberto I, 1",
+                      "description":"Comune di Tovo San Giacomo",
+                      "digitalAddress":"protocollo@comunetovosangiacomo.it",
+                      "institutionType":"PA",
+                      "origin":"IPA",
+                      "originId":"c_l315",
+                      "taxCode":"00338460090"
+                   },
+                   "internalIstitutionID":"7861b02d-8cb4-4de9-95d2-5ed02f3de38a",
+                   "onboardingTokenId":"7014954b-5a2f-4aed-9f26-b2b778c2a120",
+                   "product":"prod-io",
+                   "state":"ACTIVE",
+                   "updatedAt":"2023-01-10T15:20:38.94Z"
+                }
+                """;
+    }
+
+}

--- a/src/test/java/it/pagopa/pn/external/registries/middleware/queue/consumer/kafka/onboarding/OnBoardingSelfCareDTODeserializerTest.java
+++ b/src/test/java/it/pagopa/pn/external/registries/middleware/queue/consumer/kafka/onboarding/OnBoardingSelfCareDTODeserializerTest.java
@@ -1,0 +1,69 @@
+package it.pagopa.pn.external.registries.middleware.queue.consumer.kafka.onboarding;
+
+import it.pagopa.pn.external.registries.middleware.queue.consumer.kafka.onboarding.onboarding.OnBoardingSelfCareDTO;
+import it.pagopa.pn.external.registries.middleware.queue.consumer.kafka.onboarding.onboarding.OnBoardingSelfCareDTODeserializer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OnBoardingSelfCareDTODeserializerTest {
+
+
+    private OnBoardingSelfCareDTODeserializer deserializer;
+
+    @BeforeEach
+    public void init() {
+        deserializer = new OnBoardingSelfCareDTODeserializer();
+    }
+
+
+    @Test
+    void deserializeTest() {
+        String requestFromSelfCare = inputRequestFormSelfCare();
+
+        OnBoardingSelfCareDTO actual = deserializer.deserialize("topic", requestFromSelfCare.getBytes());
+
+        assertThat(actual).isNotNull();
+        assertThat(actual.getInternalIstitutionID()).isEqualTo("7861b02d-8cb4-4de9-95d2-5ed02f3de38a");
+        assertThat(actual.getState()).isEqualTo("ACTIVE");
+        assertThat(actual.getUpdatedAt()).isEqualTo(Instant.parse("2023-01-10T15:20:38.94Z"));
+        assertThat(actual.getInstitution().getAddress()).isEqualTo("Piazza Umberto I, 1");
+        assertThat(actual.getInstitution().getDigitalAddress()).isEqualTo("protocollo@comunetovosangiacomo.it");
+        assertThat(actual.getInstitution().getTaxCode()).isEqualTo("00338460090");
+        assertThat(actual.getInstitution().getDescription()).isEqualTo("Comune di Tovo San Giacomo");
+    }
+
+
+    private String inputRequestFormSelfCare() {
+        return """
+                {
+                   "billing":{
+                      "recipientCode":"bc_0432",
+                      "vatNumber":"00338460090"
+                   },
+                   "contentType":"application/octet-stream",
+                   "fileName":"App IO_accordo_adesione.pdf7419256794741715935.pdf",
+                   "filePath":"parties/docs/7014954b-5a2f-4aed-9f26-b2b778c2a120/App IO_accordo_adesione.pdf7419256794741715935.pdf",
+                   "id":"7014954b-5a2f-4aed-9f26-b2b778c2a120",
+                   "institution":{
+                      "address":"Piazza Umberto I, 1",
+                      "description":"Comune di Tovo San Giacomo",
+                      "digitalAddress":"protocollo@comunetovosangiacomo.it",
+                      "institutionType":"PA",
+                      "origin":"IPA",
+                      "originId":"c_l315",
+                      "taxCode":"00338460090"
+                   },
+                   "internalIstitutionID":"7861b02d-8cb4-4de9-95d2-5ed02f3de38a",
+                   "onboardingTokenId":"7014954b-5a2f-4aed-9f26-b2b778c2a120",
+                   "product":"prod-io",
+                   "state":"ACTIVE",
+                   "updatedAt":"2023-01-10T15:20:38.94Z"
+                }
+                """;
+    }
+
+}

--- a/src/test/java/it/pagopa/pn/external/registries/services/InfoSelfcareGroupsServiceTest.java
+++ b/src/test/java/it/pagopa/pn/external/registries/services/InfoSelfcareGroupsServiceTest.java
@@ -1,6 +1,5 @@
 package it.pagopa.pn.external.registries.services;
 
-import it.pagopa.pn.external.registries.LocalStackTestConfig;
 import it.pagopa.pn.external.registries.generated.openapi.selfcare.external.client.v1.dto.PageOfUserGroupResourceDto;
 import it.pagopa.pn.external.registries.generated.openapi.selfcare.external.client.v1.dto.UserGroupResourceDto;
 import it.pagopa.pn.external.registries.generated.openapi.server.ipa.v1.dto.PaGroupDto;
@@ -8,14 +7,12 @@ import it.pagopa.pn.external.registries.generated.openapi.server.ipa.v1.dto.PaGr
 import it.pagopa.pn.external.registries.middleware.msclient.SelfcareInstitutionsClient;
 import it.pagopa.pn.external.registries.middleware.msclient.SelfcareUserGroupClient;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
@@ -25,21 +22,20 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@SpringBootTest
-@Import(LocalStackTestConfig.class)
+
+@ExtendWith(MockitoExtension.class)
 @Slf4j
-@ActiveProfiles("test")
 class InfoSelfcareGroupsServiceTest {
 
     private final Duration d = Duration.ofMillis(3000);
 
-    @Autowired
+    @InjectMocks
     private InfoSelfcareGroupsService service;
 
-    @MockBean
+    @Mock
     private SelfcareInstitutionsClient selfcareInstitutionsClient;
 
-    @MockBean
+    @Mock
     private SelfcareUserGroupClient selfcareUserGroupClient;
 
     @Test

--- a/src/test/java/it/pagopa/pn/external/registries/services/InfoSelfcareInstitutionsServiceTest.java
+++ b/src/test/java/it/pagopa/pn/external/registries/services/InfoSelfcareInstitutionsServiceTest.java
@@ -1,6 +1,5 @@
 package it.pagopa.pn.external.registries.services;
 
-import it.pagopa.pn.external.registries.LocalStackTestConfig;
 import it.pagopa.pn.external.registries.exceptions.PnPANotFoundException;
 import it.pagopa.pn.external.registries.generated.openapi.server.ipa.v1.dto.PaInfoDto;
 import it.pagopa.pn.external.registries.generated.openapi.server.ipa.v1.dto.PaSummaryDto;
@@ -9,12 +8,11 @@ import it.pagopa.pn.external.registries.middleware.db.entities.OnboardInstitutio
 import it.pagopa.pn.external.registries.services.helpers.OnboardInstitutionFulltextSearchHelper;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -25,21 +23,19 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest
-@Import(LocalStackTestConfig.class)
+@ExtendWith(MockitoExtension.class)
 @Slf4j
-@ActiveProfiles("test")
 class InfoSelfcareInstitutionsServiceTest {
 
     private final Duration d = Duration.ofMillis(3000);
 
-    @Autowired
+    @InjectMocks
     private InfoSelfcareInstitutionsService service;
 
-    @MockBean
+    @Mock
     private OnboardInstitutionsDao onboardInstitutionsDao;
 
-    @MockBean
+    @Mock
     private OnboardInstitutionFulltextSearchHelper onboardInstitutionFulltextSearchHelper;
 
     @Test

--- a/src/test/java/it/pagopa/pn/external/registries/services/MVPValidUserServiceTest.java
+++ b/src/test/java/it/pagopa/pn/external/registries/services/MVPValidUserServiceTest.java
@@ -6,10 +6,11 @@ import it.pagopa.pn.external.registries.middleware.msclient.io.IOOptInClient;
 import it.pagopa.pn.external.registries.middleware.queue.producer.sqs.SqsNotificationPaidProducer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -17,7 +18,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.Collections;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class MVPValidUserServiceTest {
 
     private static final String TAX_ID = "EEEEEE00E00E000A";

--- a/src/test/java/it/pagopa/pn/external/registries/services/helpers/OnboardInstitutionFulltextSearchHelperTest.java
+++ b/src/test/java/it/pagopa/pn/external/registries/services/helpers/OnboardInstitutionFulltextSearchHelperTest.java
@@ -9,32 +9,29 @@ import it.pagopa.pn.external.registries.generated.openapi.server.ipa.v1.dto.PaSu
 import it.pagopa.pn.external.registries.middleware.db.dao.OnboardInstitutionsDao;
 import it.pagopa.pn.external.registries.middleware.db.entities.OnboardInstitutionEntity;
 import it.pagopa.pn.external.registries.middleware.db.io.dao.TestDao;
-import it.pagopa.pn.external.registries.middleware.db.io.entities.OptInSentEntity;
+import it.pagopa.pn.external.registries.middleware.queue.consumer.kafka.onboarding.onboarding.OnBoardingSelfCareConsumer;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.util.ResourceUtils;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 @Import(LocalStackTestConfig.class)
@@ -56,6 +53,9 @@ class OnboardInstitutionFulltextSearchHelperTest {
 
     @Autowired
     OnboardInstitutionFulltextSearchHelper onboardInstitutionFulltextSearchHelper;
+
+    @MockBean
+    private OnBoardingSelfCareConsumer onBoardingSelfCareConsumer;
 
     @BeforeEach
     public void beforeeach() throws IOException {

--- a/src/test/java/it/pagopa/pn/external/registries/services/io/IOActivationServiceTest.java
+++ b/src/test/java/it/pagopa/pn/external/registries/services/io/IOActivationServiceTest.java
@@ -4,16 +4,13 @@ import it.pagopa.pn.external.registries.config.PnExternalRegistriesConfig;
 import it.pagopa.pn.external.registries.generated.openapi.io.client.v1.dto.Activation;
 import it.pagopa.pn.external.registries.generated.openapi.server.io.v1.dto.*;
 import it.pagopa.pn.external.registries.middleware.msclient.io.IOCourtesyMessageClient;
-import it.pagopa.pn.external.registries.middleware.queue.producer.sqs.SqsNotificationPaidProducer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 
 import java.time.Instant;
@@ -22,7 +19,7 @@ import java.time.ZoneId;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class IOActivationServiceTest {
 
     @InjectMocks
@@ -33,15 +30,6 @@ class IOActivationServiceTest {
 
     @Mock
     PnExternalRegistriesConfig cfg;
-
-    @Configuration
-    static class ContextConfiguration {
-        @Primary
-        @Bean
-        public SqsNotificationPaidProducer sqsNotificationPaidProducer() {
-            return Mockito.mock( SqsNotificationPaidProducer.class);
-        }
-    }
 
 
     @Test

--- a/src/test/java/it/pagopa/pn/external/registries/services/io/IOServiceTest.java
+++ b/src/test/java/it/pagopa/pn/external/registries/services/io/IOServiceTest.java
@@ -12,6 +12,7 @@ import it.pagopa.pn.external.registries.middleware.db.io.dao.OptInSentDao;
 import it.pagopa.pn.external.registries.middleware.db.io.entities.OptInSentEntity;
 import it.pagopa.pn.external.registries.middleware.msclient.io.IOCourtesyMessageClient;
 import it.pagopa.pn.external.registries.middleware.msclient.io.IOOptInClient;
+import it.pagopa.pn.external.registries.middleware.queue.consumer.kafka.onboarding.onboarding.OnBoardingSelfCareConsumer;
 import it.pagopa.pn.external.registries.middleware.queue.producer.sqs.SqsNotificationPaidProducer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,6 +53,9 @@ class IOServiceTest {
 
     @Mock
     PnExternalRegistriesConfig cfg;
+
+    @Mock
+    OnBoardingSelfCareConsumer onBoardingSelfCareConsumer;
 
     @Configuration
     static class ContextConfiguration {


### PR DESCRIPTION
Mergiare la PR quando il team di SelfCare ci darà l'OK per l'abilitazione della VPN della coda di EventHub di UAT verso tutti gli ambienti di PN.

Contenuto della PR:

- gestione Consumer Kafka per scodamento e salvataggio degli OnBoarding di SelfCare
- modificati alcuni test unitari che utlizzavano inutilmente il contesto di Spring