### PR TITLE
PN-5425 template IO without placeholders

### DIFF
--- a/src/main/java/it/pagopa/pn/external/registries/services/io/IOService.java
+++ b/src/main/java/it/pagopa/pn/external/registries/services/io/IOService.java
@@ -310,7 +310,9 @@ public class IOService {
         String[] schedulingDateWithHour = localDateTime.split(" ");
         responseDto.setMessageCode(PRE_ANALOG_MESSAGE_CODE);
         responseDto.setTitle(PRE_ANALOG_TITLE);
-        responseDto.setMarkdown(cfg.getAppIoTemplate().getMarkdownDisclaimerBeforeDateAppIoMessage());
+        responseDto.setMarkdown(cfg.getAppIoTemplate().getMarkdownDisclaimerBeforeDateAppIoMessage()
+                .replace(DATE_PLACEHOLDER, schedulingDateWithHour[0])
+                .replace(TIME_PLACEHOLDER, schedulingDateWithHour[1]));
         responseDto.setMessageParams(
                 Map.of(
                         DATE_MESSAGE_PARAM, schedulingDateWithHour[0],
@@ -348,9 +350,8 @@ public class IOService {
             String iun = sendMessageRequestDto.getIun();
             IOMessagesEntity ioMessagesEntity = new IOMessagesEntity();
             ioMessagesEntity.setPk(buildPkProbableSchedulingAnalogDate(iun, recipientInternalID));
-            ioMessagesEntity.setSchedulingAnalogDate(sendMessageRequestDto.getSchedulingAnalogDate() != null ?
-                    sendMessageRequestDto.getSchedulingAnalogDate().toInstant() : null);
-            ioMessagesEntity.setTtl(LocalDateTime.from(sendMessageRequestDto.getRequestAcceptedDate()).plusDays(2).atZone(ZoneId.systemDefault()).toEpochSecond());
+            ioMessagesEntity.setSchedulingAnalogDate(sendMessageRequestDto.getSchedulingAnalogDate().toInstant());
+            ioMessagesEntity.setTtl(LocalDateTime.from(sendMessageRequestDto.getSchedulingAnalogDate()).plusDays(2).atZone(ZoneId.systemDefault()).toEpochSecond());
             return ioMessagesDao.save(ioMessagesEntity);
         }
         else {

--- a/src/main/java/it/pagopa/pn/external/registries/util/AppIOUtils.java
+++ b/src/main/java/it/pagopa/pn/external/registries/util/AppIOUtils.java
@@ -13,6 +13,9 @@ public class AppIOUtils {
     public static final String DATE_MESSAGE_PARAM = "data";
     public static final String TIME_MESSAGE_PARAM = "ora";
 
+    public static final String DATE_PLACEHOLDER = "{{data}}";
+    public static final String TIME_PLACEHOLDER = "{{ora}}";
+
     public static final String PROBABLE_SCHEDULING_ANALOG_DATE_PK_PREFIX = "SENT";
     public static final String PROBABLE_SCHEDULING_ANALOG_DATE_DELIMITER_PK = "##";
     public static final DateTimeFormatter PROBABLE_SCHEDULING_ANALOG_DATE_DATE_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");

--- a/src/test/java/it/pagopa/pn/external/registries/services/io/IOServiceTest.java
+++ b/src/test/java/it/pagopa/pn/external/registries/services/io/IOServiceTest.java
@@ -219,6 +219,7 @@ class IOServiceTest {
         // verifico che è stato inserito il record per il ioMessagesEntity (probableSchedulingAnalogDate)
         assertThat(ioMessagesEntityCaptor.getValue().getPk()).isEqualTo("SENT##" + messageRequestDto.getIun() + "##" + messageRequestDto.getRecipientInternalID());
         assertThat(ioMessagesEntityCaptor.getValue().getSchedulingAnalogDate()).isEqualTo(messageRequestDto.getSchedulingAnalogDate().toInstant());
+        assertThat(ioMessagesEntityCaptor.getValue().getTtl()).isEqualTo(messageRequestDto.getSchedulingAnalogDate().toInstant().plus(2, ChronoUnit.DAYS).getEpochSecond());
     }
 
     @Test
@@ -279,6 +280,7 @@ class IOServiceTest {
         // verifico che è stato inserito il record per il ioMessagesEntity (probableSchedulingAnalogDate)
         assertThat(ioMessagesEntityCaptor.getValue().getPk()).isEqualTo("SENT##" + messageRequestDto.getIun() + "##" + messageRequestDto.getRecipientInternalID());
         assertThat(ioMessagesEntityCaptor.getValue().getSchedulingAnalogDate()).isEqualTo(messageRequestDto.getSchedulingAnalogDate().toInstant());
+        assertThat(ioMessagesEntityCaptor.getValue().getTtl()).isEqualTo(messageRequestDto.getSchedulingAnalogDate().toInstant().plus(2, ChronoUnit.DAYS).getEpochSecond());
     }
 
     @Test
@@ -678,7 +680,9 @@ class IOServiceTest {
         PreconditionContentDto expectedResponse = new PreconditionContentDto()
                 .messageCode(PRE_ANALOG_MESSAGE_CODE)
                         .title(PRE_ANALOG_TITLE)
-                                .markdown(pnExternalRegistriesConfig.getAppIoTemplate().getMarkdownDisclaimerBeforeDateAppIoMessage())
+                                .markdown(pnExternalRegistriesConfig.getAppIoTemplate().getMarkdownDisclaimerBeforeDateAppIoMessage()
+                                        .replace(DATE_PLACEHOLDER, "03-05-2050")
+                                        .replace(TIME_PLACEHOLDER, "13:51"))
                 .messageParams(Map.of(
                         DATE_MESSAGE_PARAM, "03-05-2050",
                         TIME_MESSAGE_PARAM, "13:51"
@@ -778,7 +782,9 @@ class IOServiceTest {
         PreconditionContentDto expectedResponse = new PreconditionContentDto()
                 .messageCode(PRE_ANALOG_MESSAGE_CODE)
                 .title(PRE_ANALOG_TITLE)
-                .markdown(pnExternalRegistriesConfig.getAppIoTemplate().getMarkdownDisclaimerBeforeDateAppIoMessage())
+                .markdown(pnExternalRegistriesConfig.getAppIoTemplate().getMarkdownDisclaimerBeforeDateAppIoMessage()
+                        .replace(DATE_PLACEHOLDER, "03-05-2050")
+                        .replace(TIME_PLACEHOLDER, "13:51"))
                 .messageParams(Map.of(
                         DATE_MESSAGE_PARAM, "03-05-2050",
                         TIME_MESSAGE_PARAM, "13:51"


### PR DESCRIPTION
Modifiche effettuate:

1. Nel template restituito a IO nel servizio **notificationDisclaimer**, non sono presenti più i placeholders {{data}} e {{ora}}, sono stati sostituiti dai valori di questi ultimi.
2. Corretto refuso del valore del ttl della tabella pn-IOMessages, dove veniva preso in cosiderazione erroneamente il requestAcceptedDate del sendMessageRequest invece dello **schedulingAnalogDate**.
3. Aggiunti assert nei test per testare il punto 2.