### PR TITLE
feat(PN-14782,IOCOM-2233): remove unnecessary `<br />` tags from `appio_message_templates`

### DIFF
--- a/src/main/resources/appio_message_templates/markdown_disclaimer_after_date_app_io_message.md
+++ b/src/main/resources/appio_message_templates/markdown_disclaimer_after_date_app_io_message.md
@@ -1,10 +1,8 @@
 Premendo “Continua”, la notifica risulterà legalmente recapitata a te, a meno che tu non abbia ricevuto la raccomandata cartacea da più di 10 giorni.
 
-<br />
-<br />
 
-__Mittente__ <br />
+__Mittente__ 
 {{senderDenomination}}
 
-__Codice IUN__ <br />
+__Codice IUN__ 
 {{iun}}

--- a/src/main/resources/appio_message_templates/markdown_disclaimer_before_date_app_io_message.md
+++ b/src/main/resources/appio_message_templates/markdown_disclaimer_before_date_app_io_message.md
@@ -1,12 +1,9 @@
 Premendo “Continua”, la notifica risulterà legalmente recapitata a te. 
-<br/>
 **Se apri il messaggio entro il {{data}} alle {{ora}}**, eviterai di ricevere la raccomandata, i cui costi saranno eventualmente calcolati in fase di pagamento.
 
-<br />
-<br />
 
-**Mittente** <br />
+**Mittente** 
 {{senderDenomination}}
 
-**Codice IUN**  <br />
+**Codice IUN** 
 {{iun}}


### PR DESCRIPTION
This PR removes `<br />` tags from markdown content in 
- `markdown_disclaimer_after_date_app_io_message.md`
- `markdown_disclaimer_before_date_app_io_message.md`

Such files are used to send the content of legal preconditions to App IO, when the Citizen opens a SEND message and has to accept the preconditions (in order to see the message's content). 

`<br />` tags embedded in markdown content are ignored in the current preconditions' visualizer, so they can be removed safely. Moreover, App IO will soon adopt a new visualizer that adheres to markdown rules more closely, and such tags would have produced unnecessary new line returns. 