### PR TITLE
19512: add configurable read timeout and retry for Checkout HTTP client

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -13,6 +13,8 @@ pn.external-registry.pdnd-server-url=https://uat.gateway.test.pdnd-interop.pagop
 pn.external-registry.checkout-api-base-url=https://api.uat.platform.pagopa.it/ecommerce/payment-requests-service/v1
 pn.external-registry.checkout-api-key=fake_api_key
 pn.external-registry.checkout-cart-api-base-url=https://api.uat.platform.pagopa.it/checkout/ec/v1
+pn.external-registry.checkout-retry-max-attempts=0
+pn.external-registry.checkout-read-timeout-millis=8000
 
 # Delivery configurations
 pn.external-registry.delivery-base-url=http://localhost:8080

--- a/scripts/aws/cfn/microservice-dev-cfg.json
+++ b/scripts/aws/cfn/microservice-dev-cfg.json
@@ -28,6 +28,8 @@
     "IoRemoteContentCfgId": "01HMVMHCZZ8D0VTFWMRHBM5D6F",
     "SendPortalUrl": "https://notifichedigitali.pagopa.it",
     "OneTrustReadTimeoutMillis": "3000",
-    "OneTrustRetryMaxAttempts": "1"
+    "OneTrustRetryMaxAttempts": "1",
+    "CheckoutRetryMaxAttempts": "0",
+    "CheckoutReadTimeoutMillis": "8000"
   }
 }

--- a/scripts/aws/cfn/microservice.yml
+++ b/scripts/aws/cfn/microservice.yml
@@ -107,6 +107,16 @@ Parameters:
     Description: 'One Trust HTTP number of max retries'
     Default: 1
 
+  CheckoutRetryMaxAttempts:
+    Type: Number
+    Description: 'Checkout HTTP number of max retries'
+    Default: 0
+
+  CheckoutReadTimeoutMillis:
+    Type: Number
+    Description: 'Checkout HTTP read timeout in milliseconds'
+    Default: 8000
+
   ContainerImageUri:
     Type: String
     Description: 'Exact container image URI with full repository and image digest'
@@ -499,11 +509,13 @@ Resources:
         ContainerEnvEntry30: !Sub 'PN_EXTERNAL_REGISTRY_PIATTAFORMANOTIFICHEURL_CITTADINI=${SendPortalUrl}/cittadini'
         ContainerEnvEntry31: !Sub 'PN_EXTERNAL_REGISTRY_ONETRUST_READ_TIMEOUT_MILLIS=${OneTrustReadTimeoutMillis}'
         ContainerEnvEntry32: !Sub 'PN_EXTERNAL_REGISTRY_ONETRUST_RETRY_MAX_ATTEMPTS=${OneTrustRetryMaxAttempts}'
+        ContainerEnvEntry33: !Sub 'PN_EXTERNAL_REGISTRY_CHECKOUT_RETRY_MAX_ATTEMPTS=${CheckoutRetryMaxAttempts}'
         ContainerEnvEntry34: !Sub "LOLLIPOP_IDP_REST_CONFIG_READ_TIMEOUT=${LollipopIdpRestConfigReadTimeout}"
         ContainerEnvEntry35: !Sub "LOLLIPOP_IDP_REST_CONFIG_CONNECTION_TIMEOUT=${LollipopIdpRestConfigConnectionTimeout}"
         ContainerEnvEntry36: !Sub "LOLLIPOP_ASSERTION_REST_CONFIG_READ_TIMEOUT=${LollipopAssertionRestConfigReadTimeout}"
         ContainerEnvEntry37: !Sub "LOLLIPOP_ASSERTION_REST_CONFIG_CONNECTION_TIMEOUT=${LollipopAssertionRestConfigConnectionTimeout}"
         ContainerEnvEntry38: !Sub "PN_EXTERNAL_REGISTRY_TOPICS_DELIVERY_PUSH_TO_EXTERNAL_REGISTRIES=${DeliveryPushToExternalRegistriesQueueName}"
+        ContainerEnvEntry39: !Sub 'PN_EXTERNAL_REGISTRY_CHECKOUT_READ_TIMEOUT_MILLIS=${CheckoutReadTimeoutMillis}'
         ContainerSecret1: !Sub 'PN_EXTERNAL_REGISTRY_CHECKOUT_API_KEY=arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:pn-ExternalRegistries-Secrets:CheckoutApiKey:AWSCURRENT:'
         ContainerSecret2: !Sub 'PN_EXTERNAL_REGISTRY_IO_API_KEY=arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:pn-ExternalRegistries-Secrets:IoApiKey:AWSCURRENT:'
         ContainerSecret3: !Sub 'PN_EXTERNAL_REGISTRY_SELFCAREUSERGROUP_API_KEY=arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:pn-ExternalRegistries-Secrets:SelfCareApiKey:AWSCURRENT:'
@@ -593,6 +605,8 @@ Resources:
         ContainerEnvEntry36: !Sub "LOLLIPOP_ASSERTION_REST_CONFIG_READ_TIMEOUT=${LollipopAssertionRestConfigReadTimeout}"
         ContainerEnvEntry37: !Sub "LOLLIPOP_ASSERTION_REST_CONFIG_CONNECTION_TIMEOUT=${LollipopAssertionRestConfigConnectionTimeout}"
         ContainerEnvEntry38: !Sub "PN_EXTERNAL_REGISTRY_TOPICS_DELIVERY_PUSH_TO_EXTERNAL_REGISTRIES=${DeliveryPushToExternalRegistriesQueueName}"
+        ContainerEnvEntry39: !Sub 'PN_EXTERNAL_REGISTRY_CHECKOUT_RETRY_MAX_ATTEMPTS=${CheckoutRetryMaxAttempts}'
+        ContainerEnvEntry40: !Sub 'PN_EXTERNAL_REGISTRY_CHECKOUT_READ_TIMEOUT_MILLIS=${CheckoutReadTimeoutMillis}'
         ContainerSecret1: !Sub 'PN_EXTERNAL_REGISTRY_CHECKOUT_API_KEY=arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:pn-ExternalRegistries-Secrets:CheckoutApiKey:AWSCURRENT:'
         ContainerSecret2: !Sub 'PN_EXTERNAL_REGISTRY_IO_API_KEY=arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:pn-ExternalRegistries-Secrets:IoApiKey:AWSCURRENT:'
         ContainerSecret3: !Sub 'PN_EXTERNAL_REGISTRY_SELFCAREUSERGROUP_API_KEY=arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:pn-ExternalRegistries-Secrets:SelfCareApiKey:AWSCURRENT:'

--- a/src/main/java/it/pagopa/pn/external/registries/config/MsClientConfig.java
+++ b/src/main/java/it/pagopa/pn/external/registries/config/MsClientConfig.java
@@ -14,6 +14,8 @@ import it.pagopa.pn.external.registries.middleware.msclient.common.OcpBaseClient
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -23,6 +25,20 @@ public class MsClientConfig {
 
     @Configuration
     static class CheckoutApis extends OcpBaseClient {
+
+        @Autowired
+        @Override
+        public void setRetryMaxAttempts(
+                @Value("${pn.external-registry.checkout-retry-max-attempts}") int retryMaxAttempts) {
+            super.setRetryMaxAttempts(retryMaxAttempts);
+        }
+
+        @Autowired
+        @Override
+        public void setReadTimeoutMillis(
+                @Value("${pn.external-registry.checkout-read-timeout-millis}") int readTimeoutMillis) {
+            super.setReadTimeoutMillis(readTimeoutMillis);
+        }
 
         @Bean
         PaymentRequestsApi defaultApiClient(PnExternalRegistriesConfig config) {

--- a/src/main/java/it/pagopa/pn/external/registries/middleware/queue/utils/ConsumerUtils.java
+++ b/src/main/java/it/pagopa/pn/external/registries/middleware/queue/utils/ConsumerUtils.java
@@ -2,8 +2,8 @@ package it.pagopa.pn.external.registries.middleware.queue.utils;
 
 import it.pagopa.pn.commons.utils.MDCUtils;
 import org.slf4j.MDC;
-import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.Message;
 
 import java.util.UUID;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,6 +26,9 @@ pn.external-registry.onetrust-base-url=https://app-de.onetrust.com
 pn.external-registry.onetrust-read-timeout-millis=3000
 pn.external-registry.onetrust-retry-max-attempts=1
 
+pn.external-registry.checkout-retry-max-attempts=${PN_EXTERNAL_REGISTRY_CHECKOUT_RETRY_MAX_ATTEMPTS:0}
+pn.external-registry.checkout-read-timeout-millis=${PN_EXTERNAL_REGISTRY_CHECKOUT_READ_TIMEOUT_MILLIS:8000}
+
 # Fix null object in serialization
 spring.jackson.default-property-inclusion = NON_NULL
 

--- a/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/CheckoutClientTest.java
+++ b/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/CheckoutClientTest.java
@@ -17,8 +17,13 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.test.StepVerifier;
+
+import io.netty.handler.timeout.ReadTimeoutException;
+import org.mockserver.model.Delay;
+import java.util.concurrent.TimeUnit;
 
 import java.net.URI;
 import java.util.List;
@@ -32,7 +37,9 @@ import static org.mockserver.model.HttpResponse.response;
 @TestPropertySource(properties = {
         "pn.external-registry.checkout-api-base-url=http://localhost:9999",
         "pn.external-registry.checkout-api-key=fake_api_key",
-        "pn.external-registry.checkout-cart-api-base-url=http://localhost:9999"
+        "pn.external-registry.checkout-cart-api-base-url=http://localhost:9999",
+        "pn.external-registry.checkout-read-timeout-millis=1000",
+        "pn.external-registry.checkout-retry-max-attempts=0"
 })
 class CheckoutClientTest extends MockAWSObjectsTestConfig {
 
@@ -180,5 +187,25 @@ class CheckoutClientTest extends MockAWSObjectsTestConfig {
         StepVerifier.create(client.checkoutCart(cartRequestDto))
             .expectErrorMatches(throwable -> throwable instanceof WebClientResponseException.NotFound)
             .verify();
+    }
+
+    @Test
+    void getPaymentInfoReadTimeout() {
+        new MockServerClient("localhost", 9999)
+                .when(request()
+                        .withMethod("GET")
+                        .withPath("/payment-requests/77777777777302000100000019421"))
+                .respond(response()
+                        .withDelay(Delay.delay(TimeUnit.SECONDS, 5))
+                        .withBody("{}")
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withStatusCode(200));
+
+        StepVerifier.create(client.getPaymentInfo("77777777777302000100000019421"))
+                .expectErrorMatches(throwable ->
+                        throwable instanceof WebClientRequestException wex
+                                && wex.getMostSpecificCause() instanceof ReadTimeoutException
+                )
+                .verify();
     }
 }


### PR DESCRIPTION
- Add checkout-read-timeout-millis and checkout-retry-max-attempts properties

- Wire properties in MsClientConfig.CheckoutApis via @Autowired/@Value, mirroring the existing OneTrust pattern

- Add CheckoutRetryMaxAttempts and CheckoutReadTimeoutMillis parameters in microservice.yml (CFN) e microservice-dev-cfg.json

- Add test getPaymentInfoReadTimeout in CheckoutClientTest to assert ReadTimeoutException when the Checkout service exceeds the read timeout