### PR TITLE
PN-20055: handle selfcare errors, replaced webClientResponseException…

### DIFF
--- a/src/main/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcarePaInstitutionClient.java
+++ b/src/main/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcarePaInstitutionClient.java
@@ -11,6 +11,7 @@ import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
+import org.springframework.web.reactive.function.client.WebClientException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -33,9 +34,10 @@ public class SelfcarePaInstitutionClient {
         log.logInvokingExternalDownstreamService(SELFCARE_PA, "getInstitutions");
         return institutionsApi.getInstitutionsUsingGET(userIdForAuth)
                 .doOnNext(institutionsResponseDto -> log.info("getInstitutions result: {}", institutionsResponseDto))
-                .onErrorResume(WebClientResponseException.class, x -> {
-                    log.logInvokationResultDownstreamFailed(SELFCARE_PA, CommonBaseClient.elabExceptionMessage(x),x);
-                    log.error("getInstitutions for userId " + userIdForAuth + " response error {}", x.getResponseBodyAsString(), x);
+                .onErrorResume(WebClientException.class, x -> {
+                    log.logInvokationResultDownstreamFailed(SELFCARE_PA, CommonBaseClient.elabExceptionMessage(x), x);
+                    String body = (x instanceof WebClientResponseException wcre) ? wcre.getResponseBodyAsString() : x.getMessage();
+                    log.error("getInstitutions for userId " + userIdForAuth + " response error {}", body, x);
                     return Mono.error(new PnInternalException("Error getting institutions", ERROR_CODE_EXTERNALREGISTRIES_INSTITUTIONSERROR, x));
                 });
     }
@@ -57,9 +59,10 @@ public class SelfcarePaInstitutionClient {
         return institutionsApi.getUserInstitutionsUsingGET(null, userIdForAuth, null, null, null, null, page,size)
                 .doOnNext(institutionsResponseDto -> log.info("getInstitutions result: {}", institutionsResponseDto))
                 .collectList()
-                .onErrorResume(WebClientResponseException.class, x -> {
-                    log.logInvokationResultDownstreamFailed(SELFCARE_PA, CommonBaseClient.elabExceptionMessage(x),x);
-                    log.error("getInstitutions for userId " + userIdForAuth + " response error {}", x.getResponseBodyAsString(), x);
+                .onErrorResume(WebClientException.class, x -> {
+                    log.logInvokationResultDownstreamFailed(SELFCARE_PA, CommonBaseClient.elabExceptionMessage(x), x);
+                    String body = (x instanceof WebClientResponseException wcre) ? wcre.getResponseBodyAsString() : x.getMessage();
+                    log.error("getInstitutions for userId " + userIdForAuth + " response error {}", body, x);
                     return Mono.error(new PnInternalException("Error getting institutions", ERROR_CODE_EXTERNALREGISTRIES_INSTITUTIONSERROR, x));
                 });
     }
@@ -68,9 +71,10 @@ public class SelfcarePaInstitutionClient {
         log.logInvokingExternalDownstreamService(SELFCARE_PA, "getInstitutions");
         return institutionsApi.getInstitutionUserProductsUsingGET(institutionId, userId)
                 .doOnNext(productResourceDto -> log.info("getInstitutionProduct result: {}", productResourceDto))
-                .onErrorResume(WebClientResponseException.class, x -> {
-                    log.logInvokationResultDownstreamFailed(SELFCARE_PA, CommonBaseClient.elabExceptionMessage(x),x);
-                    log.error("getInstitutionProduct for institutionId " + institutionId + " response error {}", x.getResponseBodyAsString(), x);
+                .onErrorResume(WebClientException.class, x -> {
+                    log.logInvokationResultDownstreamFailed(SELFCARE_PA, CommonBaseClient.elabExceptionMessage(x), x);
+                    String body = (x instanceof WebClientResponseException wcre) ? wcre.getResponseBodyAsString() : x.getMessage();
+                    log.error("getInstitutionProduct for institutionId " + institutionId + " response error {}", body, x);
                     return Mono.error(new PnInternalException("Error getting product institutions", ERROR_CODE_EXTERNALREGISTRIES_INSTITUTIONSERROR, x));
                 });
     }

--- a/src/main/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcarePaUserGroupClient.java
+++ b/src/main/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcarePaUserGroupClient.java
@@ -8,6 +8,7 @@ import it.pagopa.pn.external.registries.generated.openapi.msclient.selfcare.v2.d
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClientException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
@@ -27,9 +28,10 @@ public class SelfcarePaUserGroupClient {
         log.logInvokingExternalDownstreamService(SELFCARE_PA, "getUserGroups");
         return userGroupPaApi.getUserGroupsUsingGET(config.getSelfcareusergroupUid(), institutionId, 0, 100, null, null, null)
                 .doOnNext(pageOfUserGroupResourceDto -> log.info("GetUserGroup result for institutionId {}: {}", institutionId, pageOfUserGroupResourceDto))
-                .onErrorResume(WebClientResponseException.class, x -> {
-                    log.logInvokationResultDownstreamFailed(SELFCARE_PA, CommonBaseClient.elabExceptionMessage(x),x);
-                    log.error("getUserGroups response error {}", x.getResponseBodyAsString(), x);
+                .onErrorResume(WebClientException.class, x -> {
+                    log.logInvokationResultDownstreamFailed(SELFCARE_PA, CommonBaseClient.elabExceptionMessage(x), x);
+                    String body = (x instanceof WebClientResponseException wcre) ? wcre.getResponseBodyAsString() : x.getMessage();
+                    log.error("getUserGroups response error {}", body, x);
                     return Mono.error(new PnInternalException("Errore lettura usergroups", ERROR_CODE_EXTERNALREGISTRIES_USERGROUPSREADERROR, x));
                 });
     }

--- a/src/main/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcarePgInstitutionClient.java
+++ b/src/main/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcarePgInstitutionClient.java
@@ -10,6 +10,7 @@ import it.pagopa.pn.external.registries.generated.openapi.msclient.selfcare.v2.d
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClientException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
@@ -33,9 +34,10 @@ public class SelfcarePgInstitutionClient {
                 .filter(userInstitutionResourceDtos -> !userInstitutionResourceDtos.isEmpty())
                 .switchIfEmpty(Mono.error(new PnInternalException("Error getting institutions", ERROR_CODE_EXTERNALREGISTRIES_INSTITUTIONSERROR)))
                 .map(userInstitutionResourceDtos -> userInstitutionResourceDtos.get(0))
-                .onErrorResume(WebClientResponseException.class, x -> {
-                    log.logInvokationResultDownstreamFailed(SELFCARE_PG, CommonBaseClient.elabExceptionMessage(x),x);
-                    log.error("getInstitutions for userId " + userIdForAuth + " response error {}", x.getResponseBodyAsString(), x);
+                .onErrorResume(WebClientException.class, x -> {
+                    log.logInvokationResultDownstreamFailed(SELFCARE_PG, CommonBaseClient.elabExceptionMessage(x), x);
+                    String body = (x instanceof WebClientResponseException wcre) ? wcre.getResponseBodyAsString() : x.getMessage();
+                    log.error("retrieveUserInstitution for userId {} institutionId {} downstream error {}", userIdForAuth, institutionId, body, x);
                     return Mono.error(new PnInternalException("Error getting institutions", ERROR_CODE_EXTERNALREGISTRIES_INSTITUTIONSERROR, x));
                 });
     }
@@ -44,9 +46,10 @@ public class SelfcarePgInstitutionClient {
     public Mono<UserResponseDto> retrieveUserDetail(String xPagopaPnUid, String xPagopaPnCxId) {
         return userPgApi.getUserInfoUsingGET(xPagopaPnUid, xPagopaPnCxId, null)
                 .doOnNext(userResponseDto -> log.info("getUserInfoUsingGET result: {}", userResponseDto))
-                .onErrorResume(WebClientResponseException.class, x -> {
-                    log.logInvokationResultDownstreamFailed(SELFCARE_PG, CommonBaseClient.elabExceptionMessage(x),x);
-                    log.error("getUserInfoUsingGET for userId " + xPagopaPnUid + " response error {}", x.getResponseBodyAsString(), x);
+                .onErrorResume(WebClientException.class, x -> {
+                    log.logInvokationResultDownstreamFailed(SELFCARE_PG, CommonBaseClient.elabExceptionMessage(x), x);
+                    String body = (x instanceof WebClientResponseException wcre) ? wcre.getResponseBodyAsString() : x.getMessage();
+                    log.error("getUserInfoUsingGET for userId " + xPagopaPnUid + " response error {}", body, x);
                     return Mono.error(new PnInternalException("Error getting user info", ERROR_CODE_EXTERNALREGISTRIES_INSTITUTIONSERROR, x));
                 });
     }

--- a/src/main/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcarePgUserGroupClient.java
+++ b/src/main/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcarePgUserGroupClient.java
@@ -8,6 +8,7 @@ import it.pagopa.pn.external.registries.generated.openapi.msclient.selfcare.v2.d
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClientException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 import software.amazon.awssdk.utils.StringUtils;
@@ -33,9 +34,10 @@ public class SelfcarePgUserGroupClient {
         UUID userIdUuid = StringUtils.isBlank(userId) ? null : UUID.fromString(userId);
         return userGroupPgApi.getUserGroupsUsingGET(config.getSelfcarepgusergroupUid(), institutionId, 0, MAX_PAGE_SIZE, null, userIdUuid, null)
                 .doOnNext(dto -> log.info("PG GetUserGroup result for institutionId {}: {}", institutionId, dto))
-                .onErrorResume(WebClientResponseException.class, e -> {
-                    log.logInvokationResultDownstreamFailed(SELFCARE_PG, CommonBaseClient.elabExceptionMessage(e),e);
-                    log.error("PG getUserGroups response error {}", e.getResponseBodyAsString(), e);
+                .onErrorResume(WebClientException.class, e -> {
+                    log.logInvokationResultDownstreamFailed(SELFCARE_PG, CommonBaseClient.elabExceptionMessage(e), e);
+                    String body = (e instanceof WebClientResponseException wcre) ? wcre.getResponseBodyAsString() : e.getMessage();
+                    log.error("PG getUserGroups response error {}", body, e);
                     return Mono.error(new PnInternalException("Errore lettura PG usergroups", ERROR_CODE_EXTERNALREGISTRIES_USERGROUPSREADERROR, e));
                 });
     }

--- a/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcarePaInstitutionClientTest.java
+++ b/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcarePaInstitutionClientTest.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import org.mockserver.model.HttpError;
+
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -30,7 +32,8 @@ import static org.mockserver.model.HttpResponse.response;
 @SpringBootTest
 @ActiveProfiles("test")
 @TestPropertySource(properties = {
-        "pn.external-registry.selfcareusergroup-base-url=http://localhost:9999"
+        "pn.external-registry.selfcareusergroup-base-url=http://localhost:9999",
+        "pn.commons.retry-max-attempts=0"
 })
 class SelfcarePaInstitutionClientTest extends MockAWSObjectsTestConfig {
 
@@ -190,7 +193,7 @@ class SelfcarePaInstitutionClientTest extends MockAWSObjectsTestConfig {
 
         //When
         try {
-            client.getInstitutions("1a2qp213-f1cb-4021-b3d0-5241216a0633").collectList().block();
+            client.getUserInstitutions("1a2qp213-f1cb-4021-b3d0-5241216a0633").collectList().block();
         }
         catch (Exception e) {
             status = ((PnInternalException) e).getStatus();
@@ -233,5 +236,88 @@ class SelfcarePaInstitutionClientTest extends MockAWSObjectsTestConfig {
         StepVerifier.create(client.getUserInstitutions("1a2qp213-f1cb-4021-b3d0-5241216a0622"))
                 .expectNextCount(1)
                         .verifyComplete();
+    }
+
+    @Test
+    void getInstitutions_connectionError_shouldThrowPnInternalException() {
+        MockServerClient mockServerClient = new MockServerClient("localhost", 9999);
+        mockServerClient.reset();
+        mockServerClient.when(request().withMethod("GET").withPath("/institutions"))
+                .error(HttpError.error().withDropConnection(true));
+
+        StepVerifier.create(client.getInstitutions("user-id"))
+                .expectError(PnInternalException.class)
+                .verify(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void getInstitutionProducts_connectionError_shouldThrowPnInternalException() {
+        String institutionId = UUID.randomUUID().toString();
+        MockServerClient mockServerClient = new MockServerClient("localhost", 9999);
+        mockServerClient.reset();
+        mockServerClient.when(request().withMethod("GET").withPath("/institutions/" + institutionId + "/products"))
+                .error(HttpError.error().withDropConnection(true));
+
+        StepVerifier.create(client.getInstitutionProducts(institutionId, "user-id"))
+                .expectError(PnInternalException.class)
+                .verify(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void retrievePaginatedUserInstitutions_ok() throws Exception {
+        UserInstitutionResourceDto resourceDto = new UserInstitutionResourceDto();
+        resourceDto.setInstitutionId("id");
+        resourceDto.setUserId("1a2qp213-f1cb-4021-b3d0-5241216a0622");
+        byte[] responseBodyBytes = new ObjectMapper().writeValueAsBytes(List.of(resourceDto));
+
+        MockServerClient mockServerClient = new MockServerClient("localhost", 9999);
+        mockServerClient.reset();
+        mockServerClient.when(request().withMethod("GET").withPath("/users"))
+                .respond(response()
+                        .withBody(responseBodyBytes)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withStatusCode(200));
+
+        List<UserInstitutionResourceDto> result =
+                client.retrievePaginatedUserInstitutions("1a2qp213-f1cb-4021-b3d0-5241216a0622", 0, 100).block();
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(1, result.size());
+    }
+
+    @Test
+    void retrievePaginatedUserInstitutions_httpError_shouldThrowPnInternalException() {
+        MockServerClient mockServerClient = new MockServerClient("localhost", 9999);
+        mockServerClient.reset();
+        mockServerClient.when(request().withMethod("GET").withPath("/users"))
+                .respond(response().withStatusCode(500));
+
+        StepVerifier.create(client.retrievePaginatedUserInstitutions("user-id", 0, 100))
+                .expectError(PnInternalException.class)
+                .verify(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void retrievePaginatedUserInstitutions_connectionError_shouldThrowPnInternalException() {
+        MockServerClient mockServerClient = new MockServerClient("localhost", 9999);
+        mockServerClient.reset();
+        mockServerClient.when(request().withMethod("GET").withPath("/users"))
+                .error(HttpError.error().withDropConnection(true));
+
+        StepVerifier.create(client.retrievePaginatedUserInstitutions("user-id", 0, 100))
+                .expectError(PnInternalException.class)
+                .verify(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void getUserInstitutions_connectionError_shouldThrowPnInternalException() {
+        MockServerClient mockServerClient = new MockServerClient("localhost", 9999);
+        mockServerClient.reset();
+        mockServerClient.when(request().withMethod("GET").withPath("/users"))
+                .error(HttpError.error().withDropConnection(true));
+
+        StepVerifier.create(client.getUserInstitutions("user-id"))
+                .expectError(PnInternalException.class)
+                .verify(Duration.ofSeconds(5));
     }
 }

--- a/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcarePaUserGroupClientTest.java
+++ b/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcarePaUserGroupClientTest.java
@@ -3,6 +3,7 @@ package it.pagopa.pn.external.registries.middleware.msclient;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import it.pagopa.pn.commons.exceptions.PnInternalException;
 import it.pagopa.pn.external.registries.MockAWSObjectsTestConfig;
 import it.pagopa.pn.external.registries.generated.openapi.msclient.selfcare.v2.dto.PageOfUserGroupResourceDto;
 import it.pagopa.pn.external.registries.generated.openapi.msclient.selfcare.v2.dto.UserGroupResourceDto;
@@ -12,12 +13,15 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpError;
 import org.mockserver.model.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import reactor.test.StepVerifier;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,7 +32,8 @@ import static org.mockserver.model.HttpResponse.response;
 @SpringBootTest
 @ActiveProfiles("test")
 @TestPropertySource(properties = {
-        "pn.external-registry.selfcareusergroup-base-url=http://localhost:9999"
+        "pn.external-registry.selfcareusergroup-base-url=http://localhost:9999",
+        "pn.commons.retry-max-attempts=0"
 })
 class SelfcarePaUserGroupClientTest extends MockAWSObjectsTestConfig {
 
@@ -66,22 +71,46 @@ class SelfcarePaUserGroupClientTest extends MockAWSObjectsTestConfig {
             e.printStackTrace();
         }
 
-        try (MockServerClient mockServerClient = new MockServerClient("localhost", 9999)) {
-            mockServerClient.when(request()
-                            .withMethod("GET")
-                            .withPath("/user-groups"))
-                    .respond(response()
-                            .withBody(responseBodyBites)
-                            .withContentType(MediaType.APPLICATION_JSON)
-                            .withStatusCode(200));
+        MockServerClient mockServerClient = new MockServerClient("localhost", 9999);
+        mockServerClient.reset();
+        mockServerClient.when(request()
+                        .withMethod("GET")
+                        .withPath("/user-groups"))
+                .respond(response()
+                        .withBody(responseBodyBites)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withStatusCode(200));
 
-            //When
-            PageOfUserGroupResourceDto response = client.getUserGroups("77777777777302000100000019421").block();
+        //When
+        PageOfUserGroupResourceDto response = client.getUserGroups("77777777777302000100000019421").block();
 
-            //Then
-            Assertions.assertNotNull(response);
-            Assertions.assertEquals(1, response.getContent().size());
-            Assertions.assertEquals(responseDto.getContent().get(0).getName(), response.getContent().get(0).getName());
-        }
+        //Then
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals(1, response.getContent().size());
+        Assertions.assertEquals(responseDto.getContent().get(0).getName(), response.getContent().get(0).getName());
+    }
+
+    @Test
+    void getUserGroups_httpError_shouldThrowPnInternalException() {
+        MockServerClient mockServerClient = new MockServerClient("localhost", 9999);
+        mockServerClient.reset();
+        mockServerClient.when(request().withMethod("GET").withPath("/user-groups"))
+                .respond(response().withStatusCode(500));
+
+        StepVerifier.create(client.getUserGroups("institution-id"))
+                .expectError(PnInternalException.class)
+                .verify(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void getUserGroups_connectionError_shouldThrowPnInternalException() {
+        MockServerClient mockServerClient = new MockServerClient("localhost", 9999);
+        mockServerClient.reset();
+        mockServerClient.when(request().withMethod("GET").withPath("/user-groups"))
+                .error(HttpError.error().withDropConnection(true));
+
+        StepVerifier.create(client.getUserGroups("institution-id"))
+                .expectError(PnInternalException.class)
+                .verify(Duration.ofSeconds(5));
     }
 }

--- a/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcarePgInstitutionClientTest.java
+++ b/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcarePgInstitutionClientTest.java
@@ -11,13 +11,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpError;
 import org.mockserver.model.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import reactor.test.StepVerifier;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -27,16 +30,15 @@ import static org.mockserver.model.HttpResponse.response;
 @SpringBootTest
 @ActiveProfiles("test")
 @TestPropertySource(properties = {
-        "pn.external-registry.selfcarepgusergroup-base-url=http://localhost:9999"
+        "pn.external-registry.selfcarepgusergroup-base-url=http://localhost:9999",
+        "pn.commons.retry-max-attempts=0"
 })
 class SelfcarePgInstitutionClientTest extends MockAWSObjectsTestConfig {
-
 
     private static ClientAndServer mockServer;
 
     @Autowired
     private SelfcarePgInstitutionClient client;
-
 
     @BeforeEach
     public void startMockServer() {
@@ -130,11 +132,9 @@ class SelfcarePgInstitutionClientTest extends MockAWSObjectsTestConfig {
         try (MockServerClient mockServerClient = new MockServerClient("localhost", 9999)) {
             mockServerClient.when(request()
                             .withMethod("GET")
-                            .withPath("/user-info"))
+                            .withPath("/users/uid"))
                     .respond(response()
-                            .withBody("[]".getBytes(StandardCharsets.UTF_8))
-                            .withContentType(MediaType.APPLICATION_JSON)
-                            .withStatusCode(200));
+                            .withStatusCode(404));
 
             assertThrows(PnInternalException.class, () -> client.retrieveUserDetail("uid", "cxId").block());
         }
@@ -145,11 +145,47 @@ class SelfcarePgInstitutionClientTest extends MockAWSObjectsTestConfig {
         try (MockServerClient mockServerClient = new MockServerClient("localhost", 9999)) {
             mockServerClient.when(request()
                             .withMethod("GET")
-                            .withPath("/user-info"))
+                            .withPath("/users/uid"))
                     .respond(response()
                             .withStatusCode(500));
 
             assertThrows(PnInternalException.class, () -> client.retrieveUserDetail("uid", "cxId").block());
+        }
+    }
+
+    @Test
+    void retrieveUserInstitution_httpError_shouldThrowPnInternalException() {
+        try (MockServerClient mockServerClient = new MockServerClient("localhost", 9999)) {
+            mockServerClient.when(request().withMethod("GET").withPath("/users"))
+                    .respond(response().withStatusCode(500));
+
+            StepVerifier.create(client.retrieveUserInstitution("uid", "cxId"))
+                    .expectError(PnInternalException.class)
+                    .verify(Duration.ofSeconds(5));
+        }
+    }
+
+    @Test
+    void retrieveUserInstitution_connectionError_shouldThrowPnInternalException() {
+        try (MockServerClient mockServerClient = new MockServerClient("localhost", 9999)) {
+            mockServerClient.when(request().withMethod("GET").withPath("/users"))
+                    .error(HttpError.error().withDropConnection(true));
+
+            StepVerifier.create(client.retrieveUserInstitution("uid", "cxId"))
+                    .expectError(PnInternalException.class)
+                    .verify(Duration.ofSeconds(5));
+        }
+    }
+
+    @Test
+    void retrieveUserDetail_connectionError_shouldThrowPnInternalException() {
+        try (MockServerClient mockServerClient = new MockServerClient("localhost", 9999)) {
+            mockServerClient.when(request().withMethod("GET").withPath("/users/uid"))
+                    .error(HttpError.error().withDropConnection(true));
+
+            StepVerifier.create(client.retrieveUserDetail("uid", "cxId"))
+                    .expectError(PnInternalException.class)
+                    .verify(Duration.ofSeconds(5));
         }
     }
 }

--- a/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcarePgUserGroupClientTest.java
+++ b/src/test/java/it/pagopa/pn/external/registries/middleware/msclient/SelfcarePgUserGroupClientTest.java
@@ -2,6 +2,7 @@ package it.pagopa.pn.external.registries.middleware.msclient;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import it.pagopa.pn.commons.exceptions.PnInternalException;
 import it.pagopa.pn.external.registries.MockAWSObjectsTestConfig;
 import it.pagopa.pn.external.registries.generated.openapi.msclient.selfcare.v2.dto.PageOfUserGroupResourceDto;
 import it.pagopa.pn.external.registries.generated.openapi.msclient.selfcare.v2.dto.UserGroupResourceDto;
@@ -10,12 +11,15 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpError;
 import org.mockserver.model.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import reactor.test.StepVerifier;
 
+import java.time.Duration;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,16 +30,15 @@ import static org.mockserver.model.HttpResponse.response;
 @SpringBootTest
 @ActiveProfiles("test")
 @TestPropertySource(properties = {
-        "pn.external-registry.selfcarepgusergroup-base-url=http://localhost:9999"
+        "pn.external-registry.selfcarepgusergroup-base-url=http://localhost:9999",
+        "pn.commons.retry-max-attempts=0"
 })
 class SelfcarePgUserGroupClientTest extends MockAWSObjectsTestConfig {
-
 
     private static ClientAndServer mockServer;
 
     @Autowired
     private SelfcarePgUserGroupClient client;
-
 
     @BeforeAll
     public static void startMockServer() {
@@ -63,21 +66,46 @@ class SelfcarePgUserGroupClientTest extends MockAWSObjectsTestConfig {
             e.printStackTrace();
         }
 
-        try (MockServerClient mockServerClient = new MockServerClient("localhost", 9999)) {
-            mockServerClient.when(request()
-                        .withMethod("GET")
-                        .withPath("/user-groups"))
-                .respond(response()
-                        .withBody(responseBytes)
-                        .withContentType(MediaType.APPLICATION_JSON)
-                        .withStatusCode(200));
-            // When
-            PageOfUserGroupResourceDto response = client.getUserGroups("id", null).block();
+        MockServerClient mockServerClient = new MockServerClient("localhost", 9999);
+        mockServerClient.reset();
+        mockServerClient.when(request()
+                    .withMethod("GET")
+                    .withPath("/user-groups"))
+            .respond(response()
+                    .withBody(responseBytes)
+                    .withContentType(MediaType.APPLICATION_JSON)
+                    .withStatusCode(200));
 
-            // Then
-            assertNotNull(response);
-            assertEquals(1, response.getContent().size());
-            assertEquals(responseDto.getContent().get(0).getName(), response.getContent().get(0).getName());
-        }
+        // When
+        PageOfUserGroupResourceDto response = client.getUserGroups("id", null).block();
+
+        // Then
+        assertNotNull(response);
+        assertEquals(1, response.getContent().size());
+        assertEquals(responseDto.getContent().get(0).getName(), response.getContent().get(0).getName());
+    }
+
+    @Test
+    void getUserGroups_httpError_shouldThrowPnInternalException() {
+        MockServerClient mockServerClient = new MockServerClient("localhost", 9999);
+        mockServerClient.reset();
+        mockServerClient.when(request().withMethod("GET").withPath("/user-groups"))
+                .respond(response().withStatusCode(500));
+
+        StepVerifier.create(client.getUserGroups("institution-id", null))
+                .expectError(PnInternalException.class)
+                .verify(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void getUserGroups_connectionError_shouldThrowPnInternalException() {
+        MockServerClient mockServerClient = new MockServerClient("localhost", 9999);
+        mockServerClient.reset();
+        mockServerClient.when(request().withMethod("GET").withPath("/user-groups"))
+                .error(HttpError.error().withDropConnection(true));
+
+        StepVerifier.create(client.getUserGroups("institution-id", null))
+                .expectError(PnInternalException.class)
+                .verify(Duration.ofSeconds(5));
     }
 }


### PR DESCRIPTION
… with WebClientException in all Clients, Response body extracted with instanceOf pattern. Tests updated.